### PR TITLE
major refactoring

### DIFF
--- a/action.php
+++ b/action.php
@@ -7,131 +7,124 @@
  * @author     Matthias Schulte <post@lupo49.de>
  * @link       http://www.dokuwiki.org/plugin:cspheader
  */
+class action_plugin_cspheader extends DokuWiki_Action_Plugin
+{
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
-
-require_once DOKU_PLUGIN.'action.php';
-
-class action_plugin_cspheader extends DokuWiki_Action_Plugin {
-
-    /**
-     * Register the eventhandler.
-     */
-    function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('ACTION_HEADERS_SEND', 'BEFORE', $this, 'handle_headers_send');
+    /** @inheritDoc */
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('ACTION_HEADERS_SEND', 'BEFORE', $this, 'handleHeadersSend');
     }
 
     /**
      * Handler for the ACTION_HEADERS_SEND event
      */
-    function handle_headers_send(&$event, $params) {
+    public function handleHeadersSend(Doku_Event $event, $params)
+    {
         global $conf;
         $xcspheader = 'X-Content-Security-Policy: ';
-	$cspheader = 'Content-Security-Policy: ';
+        $cspheader = 'Content-Security-Policy: ';
         $cspvalues = array();
-        $addsemicolon = false;
-        
-        if($this->getConf('enableHeader')) {
-            // Take care of spaces and semicolons betweeen the directives
 
-            // host-expr examples: http://*.foo.com, mail.foo.com:443, https://store.foo.com
-            // Besides FQDNs there are some keywords which are allowed 'self', 'none' or data:-URIs
-            // Documentation: https://developer.mozilla.org/en/Security/CSP/CSP_policy_directives
-            
-            // allow host-expr
-            if($this->getConf('allowValue')) {
-                $allow = 'allow ' . $this->getConf('allowValue');
-                array_push($cspvalues, $allow);
-            }
+        if (!$this->getConf('enableHeader')) return;
 
-            // options [inline-script|eval-script]
-            if($this->getConf('optionsInline') || $this->getConf('optionsEval')) {
-                $optionsline = 'options';
+        // Take care of spaces and semicolons betweeen the directives
 
-                if($this->getConf('optionsInline')) $optionsline .= ' inline-script';
-                if($this->getConf('optionsEval')) $optionsline .= ' eval-script';
-                
-                array_push($cspvalues, $optionsline);
-            }
+        // host-expr examples: http://*.foo.com, mail.foo.com:443, https://store.foo.com
+        // Besides FQDNs there are some keywords which are allowed 'self', 'none' or data:-URIs
+        // Documentation: https://developer.mozilla.org/en/Security/CSP/CSP_policy_directives
 
-            // img-src host-expr
-            if($this->getConf('imgsrcValue')) {
-                $imgsrc = 'img-src ' . $this->getConf('imgsrcValue');
-                array_push($cspvalues, $imgsrc);
-            }
-
-            // media-src host-expr
-            if($this->getConf('mediasrcValue')) {
-                $mediasrc = ' media-src ' . $this->getConf('mediasrcValue');
-                array_push($cspvalues, $mediasrc);
-            }
-
-            // script-src host-expr
-            if($this->getConf('scriptsrcValue')) {
-                $scriptsrc = 'script-src ' . $this->getConf('scriptsrcValue');
-                array_push($cspvalues, $scriptsrc);
-            }
-            
-            // object-src host-expr
-            if($this->getConf('objectsrcValue')) {
-                $objectsrc = 'object-src ' . $this->getConf('objectsrcValue');
-                array_push($cspvalues, $objectsrc);
-            }
-
-            // frame-src host-expr
-            if($this->getConf('framesrcValue')) {
-                $framesrc = 'frame-src ' . $this->getConf('framesrcValue');
-                array_push($cspvalues, $framesrc);
-            }
-            
-            // font-src host-expr
-            if($this->getConf('fontsrcValue')) {
-                $fontsrc = 'font-src ' . $this->getConf('fontsrcValue');
-                array_push($cspvalues, $fontsrc);
-            }
-            
-            // xhr-src host-expr
-            if($this->getConf('xhrsrcValue')) {
-                $xhrsrc = 'xhr-src ' . $this->getConf('xhrsrcValue');
-                array_push($cspvalues, $xhrsrc);
-            }
-
-            // frame-ancestors host-expr
-            if($this->getConf('frameancestorsValue')) {
-                $frameancestors = 'frame-ancestors ' . $this->getConf('frameancestorsValue');
-                array_push($cspvalues, $frameancestors);
-                
-            }
-
-            // style-src host-expr
-            if($this->getConf('stylesrcValue')) {
-                $stylesrc = 'style-src ' . $this->getConf('stylesrcValue');
-                array_push($cspvalues, $stylesrc);
-            }
-            
-            // report-uri uri
-            if($this->getConf('reporturiValue')) {
-                $reportui = 'report-uri ' . $this->getConf('reporturiValue');
-                array_push($cspvalues, $reportui);
-            }
-
-            // policy-uri uri
-            if($this->getConf('policyuriValue')) {
-                $policyuri = 'policy-uri ' . $this->getConf('policyuriValue');
-                array_push($cspvalues, $policyuri);
-            }
-
-            // concat each array element seperated by a semicolon and a space
-            $xcspheader .= implode('; ', $cspvalues); 
-	    $cspheader .= implode('; ', $cspvalues);
-            
-            if($conf["allowdebug"]) msg("CSPheader plugin (DEBUG): ". $cspheader);
-            
-            // add the CSP header to the existing headers
-            array_push($event->data, $cspheader);
-	    array_push($event->data, $xcspheader);
+        // allow host-expr
+        if ($this->getConf('allowValue')) {
+            $allow = 'allow ' . $this->getConf('allowValue');
+            array_push($cspvalues, $allow);
         }
+
+        // options [inline-script|eval-script]
+        if ($this->getConf('optionsInline') || $this->getConf('optionsEval')) {
+            $optionsline = 'options';
+
+            if ($this->getConf('optionsInline')) $optionsline .= ' inline-script';
+            if ($this->getConf('optionsEval')) $optionsline .= ' eval-script';
+
+            array_push($cspvalues, $optionsline);
+        }
+
+        // img-src host-expr
+        if ($this->getConf('imgsrcValue')) {
+            $imgsrc = 'img-src ' . $this->getConf('imgsrcValue');
+            array_push($cspvalues, $imgsrc);
+        }
+
+        // media-src host-expr
+        if ($this->getConf('mediasrcValue')) {
+            $mediasrc = ' media-src ' . $this->getConf('mediasrcValue');
+            array_push($cspvalues, $mediasrc);
+        }
+
+        // script-src host-expr
+        if ($this->getConf('scriptsrcValue')) {
+            $scriptsrc = 'script-src ' . $this->getConf('scriptsrcValue');
+            array_push($cspvalues, $scriptsrc);
+        }
+
+        // object-src host-expr
+        if ($this->getConf('objectsrcValue')) {
+            $objectsrc = 'object-src ' . $this->getConf('objectsrcValue');
+            array_push($cspvalues, $objectsrc);
+        }
+
+        // frame-src host-expr
+        if ($this->getConf('framesrcValue')) {
+            $framesrc = 'frame-src ' . $this->getConf('framesrcValue');
+            array_push($cspvalues, $framesrc);
+        }
+
+        // font-src host-expr
+        if ($this->getConf('fontsrcValue')) {
+            $fontsrc = 'font-src ' . $this->getConf('fontsrcValue');
+            array_push($cspvalues, $fontsrc);
+        }
+
+        // xhr-src host-expr
+        if ($this->getConf('xhrsrcValue')) {
+            $xhrsrc = 'xhr-src ' . $this->getConf('xhrsrcValue');
+            array_push($cspvalues, $xhrsrc);
+        }
+
+        // frame-ancestors host-expr
+        if ($this->getConf('frameancestorsValue')) {
+            $frameancestors = 'frame-ancestors ' . $this->getConf('frameancestorsValue');
+            array_push($cspvalues, $frameancestors);
+
+        }
+
+        // style-src host-expr
+        if ($this->getConf('stylesrcValue')) {
+            $stylesrc = 'style-src ' . $this->getConf('stylesrcValue');
+            array_push($cspvalues, $stylesrc);
+        }
+
+        // report-uri uri
+        if ($this->getConf('reporturiValue')) {
+            $reportui = 'report-uri ' . $this->getConf('reporturiValue');
+            array_push($cspvalues, $reportui);
+        }
+
+        // policy-uri uri
+        if ($this->getConf('policyuriValue')) {
+            $policyuri = 'policy-uri ' . $this->getConf('policyuriValue');
+            array_push($cspvalues, $policyuri);
+        }
+
+        // concat each array element seperated by a semicolon and a space
+        $xcspheader .= implode('; ', $cspvalues);
+        $cspheader .= implode('; ', $cspvalues);
+
+        if ($conf["allowdebug"]) msg("CSPheader plugin (DEBUG): " . $cspheader);
+
+        // add the CSP header to the existing headers
+        array_push($event->data, $cspheader);
+        array_push($event->data, $xcspheader);
     }
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -2,22 +2,32 @@
 
 /**
  * Options for the CSP Header Plugin
- * 
+ *
  * @author    Matthias Schulte <post@lupo49.de>
  */
 
-$conf['enableHeader']        = 0;       // Enable/Disable the header
-$conf['allowValue']          = '\'self\'';  // Set value for the "allow" directive
-$conf['optionsInline']       = 0;       // Set values for tha "options inline-script" directive
-$conf['optionsEval']         = 0;       // Set values for tha "options eval-script" directive
-$conf['imgsrcValue']         = '';
-$conf['mediasrcValue']       = '';
-$conf['scriptsrcValue']      = '';
-$conf['objectsrcValue']      = '';
-$conf['framesrcValue']       = '';
-$conf['fontsrcValue']        = '';
-$conf['xhrsrcValue']         = '';
+$conf['baseuriValue'] = '\'self\'';
+$conf['childsrcValue'] = '';
+$conf['connectsrcValue'] = '';
+$conf['defaultsrcValue'] = '\'self\'';
+$conf['fontsrcValue'] = '';
+$conf['formactionValue'] = '';
 $conf['frameancestorsValue'] = '';
-$conf['stylesrcValue']       = '';
-$conf['reporturiValue']      = '';
-$conf['policyuriValue']      = '';
+$conf['framesrcValue'] = '';
+$conf['imgsrcValue'] = '';
+$conf['manifestsrcValue'] = '';
+$conf['mediasrcValue'] = '';
+$conf['navigatetoValue'] = '';
+$conf['objectsrcValue'] = '';
+$conf['plugintypesValue'] = '';
+$conf['prefetchsrcValue'] = '';
+$conf['reporturiValue'] = '';
+$conf['sandboxValue'] = '';
+$conf['scriptsrcValue'] = '';
+$conf['scriptsrcattrValue'] = '';
+$conf['scriptsrcelemValue'] = '';
+$conf['stylesrcValue'] = '';
+$conf['stylesrcattrValue'] = '';
+$conf['stylesrcelemValue'] = '';
+$conf['trustedtypesValue'] = '';
+$conf['workersrcValue'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,18 +6,28 @@
  * @author    Matthias Schulte <post@lupo49.de>
  */
 
-$meta['enableHeader']        = array('onoff');
-$meta['allowValue']          = array('string');
-$meta['optionsInline']       = array('onoff');
-$meta['optionsEval']         = array('onoff');
-$meta['imgsrcValue']         = array('string');
-$meta['mediasrcValue']       = array('string');
-$meta['scriptsrcValue']      = array('string');
-$meta['objectsrcValue']      = array('string');
-$meta['framesrcValue']       = array('string');
-$meta['fontsrcValue']        = array('string');
-$meta['xhrsrcValue']         = array('string');
-$meta['frameancestorsValue'] = array('string');
-$meta['stylesrcValue']       = array('string');
-$meta['reporturiValue']      = array('string');
-$meta['policyuriValue']      = array('string');
+$meta['defaultsrcValue'] = array('');
+$meta['childsrcValue'] = array('');
+$meta['scriptsrcValue'] = array('');
+$meta['scriptsrcattrValue'] = array('');
+$meta['scriptsrcelemValue'] = array('');
+$meta['stylesrcValue'] = array('');
+$meta['stylesrcattrValue'] = array('');
+$meta['stylesrcelemValue'] = array('');
+$meta['objectsrcValue'] = array('');
+$meta['imgsrcValue'] = array('');
+$meta['connectsrcValue'] = array('');
+$meta['fontsrcValue'] = array('');
+$meta['workersrcValue'] = array('');
+$meta['mediasrcValue'] = array('');
+$meta['manifestsrcValue'] = array('');
+$meta['prefetchsrcValue'] = array('');
+$meta['framesrcValue'] = array('');
+$meta['frameancestorsValue'] = array('');
+$meta['baseuriValue'] = array('');
+$meta['formactionValue'] = array('');
+$meta['navigatetoValue'] = array('');
+$meta['trustedtypesValue'] = array('');
+$meta['plugintypesValue'] = array('');
+$meta['sandboxValue'] = array('');
+$meta['reporturiValue'] = array('');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,19 +5,29 @@
  *
  * @author     Matthias Schulte <post@lupo49.de>
  */
- 
-$lang['enableHeader']        = 'Enables/Disables the CSP-Header';
-$lang['allowValue']          = 'Set value for the "allow"-directive';
-$lang['optionsInline']       = 'Enable/Disable the "options inline-script" directive';
-$lang['optionsEval']         = 'Enable/Disable the "options eval-script" directive';
-$lang['imgsrcValue']         = 'Set value for the "img-src"-directive';
-$lang['mediasrcValue']       = 'Set value for the "media-src"-directive';
-$lang['scriptsrcValue']      = 'Set value for the "script-src"-directive';
-$lang['objectsrcValue']      = 'Set value for the "object-src"-directive';
-$lang['framesrcValue']       = 'Set value for the "framesrc-src"-directive';
-$lang['fontsrcValue']        = 'Set value for the "font-src"-directive';
-$lang['xhrsrcValue']         = 'Set value for the "xhr-src"-directive';
-$lang['frameancestorsValue'] = 'Set value for the "frame-ancestors"-directive';
-$lang['stylesrcValue']       = 'Set value for the "style-src"-directive';
-$lang['reporturiValue']      = 'Set value for the "report-uri"-directive (URL/Port must be equal to the CSP-Host)';
-$lang['policyuriValue']      = 'Set value for the "policy-uri"-directive (conflicts with the other directives, see documentation)';
+
+$lang['baseuriValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri">base-uri</a> directive.';
+$lang['childsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src">child-src</a> directive.';
+$lang['connectsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src">connect-src</a> directive.';
+$lang['defaultsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src">default-src</a> directive.';
+$lang['fontsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src">font-src</a> directive.';
+$lang['formactionValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action">form-action</a> directive.';
+$lang['frameancestorsValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors">frame-ancestors</a> directive.';
+$lang['framesrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src">frame-src</a> directive.';
+$lang['imgsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/">img-src</a> directive.';
+$lang['manifestsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src">manifest-src</a> directive.';
+$lang['mediasrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src">media-src</a> directive.';
+$lang['navigatetoValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to">navigate-to</a> directive.';
+$lang['objectsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src">object-src</a> directive.';
+$lang['plugintypesValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types">plugin-types</a> directive.';
+$lang['prefetchsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src">prefetch-src</a> directive.';
+$lang['reporturiValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri">report-uri</a> directive.';
+$lang['sandboxValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox">sandbox</a> directive.';
+$lang['scriptsrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src">script-src</a> directive.';
+$lang['scriptsrcattrValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr">script-src-attr</a> directive.';
+$lang['scriptsrcelemValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem">script-src-elem</a> directive.';
+$lang['stylesrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/styles-src">styles-src</a> directive.';
+$lang['stylesrcattrValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/styles-src-attr">styles-src-attr</a> directive.';
+$lang['stylesrcelemValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/styles-src-elem">styles-src-attr</a> directive.';
+$lang['trustedtypesValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">trusted-types</a> directive.';
+$lang['workersrcValue'] = 'Set value for the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src">worker-src</a> directive.';


### PR DESCRIPTION
This updates the plugin to make use of the current standard.

All available policies have been updated accordingly and the old X-Content-Security-Policy header has been dropped.

The actual code has been simplified to avoid duplicate code.

The enableHeader option has been dropped as it is the same as simply disabling the plugin.

This duplicates some of the efforts of #3 by @dregad which unfortunately I overlooked before starting to work on this.